### PR TITLE
feat: Basic CLI for dispatching Hyperlane messages

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4213,6 +4213,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlane-cli"
+version = "0.1.0"
+dependencies = [
+ "clap 4.4.17",
+ "ethers",
+ "eyre",
+ "hyperlane-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "hyperlane-core"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "chains/hyperlane-sealevel",
   "ethers-prometheus",
   "hyperlane-base",
+  "hyperlane-cli",
   "hyperlane-core",
   "hyperlane-test",
   "sealevel/client",

--- a/rust/hyperlane-cli/Cargo.toml
+++ b/rust/hyperlane-cli/Cargo.toml
@@ -1,0 +1,24 @@
+cargo-features = ["workspace-inheritance"]
+
+[package]
+name = "hyperlane-cli"
+documentation = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license-file = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+ethers.workspace = true
+eyre.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing.workspace = true
+tracing-futures.workspace = true
+
+hyperlane-core = { path = "../hyperlane-core", features = ["ethers", "async"] }
+clap = { workspace = true, features = ["derive"] }
+
+[build-dependencies]
+ethers.workspace = true

--- a/rust/hyperlane-cli/Cargo.toml
+++ b/rust/hyperlane-cli/Cargo.toml
@@ -10,15 +10,16 @@ publish = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 ethers.workspace = true
 eyre.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-futures.workspace = true
 
 hyperlane-core = { path = "../hyperlane-core", features = ["ethers", "async"] }
-clap = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
 ethers.workspace = true

--- a/rust/hyperlane-cli/build.rs
+++ b/rust/hyperlane-cli/build.rs
@@ -1,0 +1,21 @@
+use ethers::contract::Abigen;
+use std::env;
+use std::path::Path;
+
+fn main() {
+    // Generate a Rust model for interfacing against the Mailbox ABI
+    let out_dir = env::current_dir().unwrap();
+    let out_file = Path::new(&out_dir).join("src/mailbox.rs");
+    if out_file.exists() {
+        std::fs::remove_file(&out_file).unwrap();
+    }
+    Abigen::new(
+        "Mailbox",
+        "../chains/hyperlane-ethereum/abis/IMailbox.abi.json",
+    )
+    .unwrap()
+    .generate()
+    .unwrap()
+    .write_to_file(out_file)
+    .unwrap();
+}

--- a/rust/hyperlane-cli/match_all.json
+++ b/rust/hyperlane-cli/match_all.json
@@ -1,0 +1,8 @@
+[
+	{
+		"origindomain": "*",
+		"senderaddress": "*",
+		"destinationdomain": "*",
+		"recipientaddress": "*"
+	}
+]

--- a/rust/hyperlane-cli/match_ethereum_origin.json
+++ b/rust/hyperlane-cli/match_ethereum_origin.json
@@ -1,0 +1,8 @@
+[
+	{
+		"origindomain": "1",
+		"senderaddress": "*",
+		"destinationdomain": "*",
+		"recipientaddress": "*"
+	}
+]

--- a/rust/hyperlane-cli/src/args.rs
+++ b/rust/hyperlane-cli/src/args.rs
@@ -1,0 +1,112 @@
+use clap::{Arg, Command};
+use ethers::{
+    core::types::{Address, Bytes, H160, H256},
+    prelude::LocalWallet,
+};
+
+#[derive(Debug)]
+pub struct Args {
+    pub rpc_url: String,
+    pub mailbox_addr: Address,
+    pub pkey: LocalWallet,
+    pub dest_chain_id: u32,
+    pub recip_addr: H256,
+    pub msg: Bytes,
+}
+
+impl Args {
+    const DISPATCH: &str = "dispatch";
+    const RPC_URL: &str = "RPC URL";
+    const MAILBOX_ADDR: &str = "mailbox address";
+    const PKEY: &str = "private key";
+    const DEST_CHAIN_ID: &str = "destination chain ID";
+    const RECIP_ADDR: &str = "recipient address";
+    const MSG: &str = "message";
+    pub fn new() -> Result<Args, Box<dyn std::error::Error>> {
+        let matches = Command::new("hyperlane-cli")
+            .about("CLI tool for dispatching Hyperlane messages and watching for Hyperlane events")
+            .subcommand_required(true)
+            .arg_required_else_help(true)
+            .allow_external_subcommands(true)
+            .subcommand(
+                Command::new(Self::DISPATCH)
+                    .about("Dispatch a Hyperlane message")
+                    .arg(
+                        Arg::new(Self::RPC_URL)
+                            .long("rpc")
+                            .required(true)
+                            .help("Origin chain RPC URL"),
+                    )
+                    .arg(
+                        Arg::new(Self::MAILBOX_ADDR)
+                            .long("mailbox")
+                            .required(true)
+                            .help("Mailbox address on the origin chain"),
+                    )
+                    .arg(
+                        Arg::new(Self::PKEY)
+                            .long("pkey")
+                            .required(true)
+                            .help("Private key for signing dispatches"),
+                    )
+                    .arg(
+                        Arg::new(Self::DEST_CHAIN_ID)
+                            .short('d')
+                            .required(true)
+                            .help("Destination chain ID"),
+                    )
+                    .arg(
+                        Arg::new(Self::RECIP_ADDR)
+                            .short('r')
+                            .required(true)
+                            .help("Recipient's address on the destination chain"),
+                    )
+                    .arg(
+                        Arg::new(Self::MSG)
+                            .required(true)
+                            .help("Message to be dispatched"),
+                    ),
+            )
+            .get_matches();
+        let dispatch_matches = matches.subcommand_matches(Self::DISPATCH).unwrap();
+        Ok(Args {
+            rpc_url: dispatch_matches
+                .get_one::<String>(Self::RPC_URL)
+                .unwrap()
+                .to_string(),
+            mailbox_addr: dispatch_matches
+                .get_one::<String>(Self::MAILBOX_ADDR)
+                .unwrap()
+                .parse::<Address>()
+                .map_err(|_| {
+                    "Mailbox address must be a 20-byte hexadecimal string without a 0x prefix"
+                })?,
+            pkey: dispatch_matches
+                .get_one::<String>(Self::PKEY)
+                .unwrap()
+                .parse::<LocalWallet>()
+                .map_err(|_| {
+                    "Signing key must be a 32-byte hexadecimal string without a 0x prefix"
+                })?,
+            dest_chain_id: dispatch_matches
+                .get_one::<String>(Self::DEST_CHAIN_ID)
+                .unwrap()
+                .parse::<u32>()
+                .map_err(|_| "Destination chain ID must be a number")?,
+            recip_addr: H256::from(
+                dispatch_matches
+                    .get_one::<String>(Self::RECIP_ADDR)
+                    .unwrap()
+                    .parse::<H160>()
+                    .map_err(|_| {
+                        "Recipient address must be a 20-byte hexadecimal string without a 0x prefix"
+                    })?,
+            ),
+            msg: dispatch_matches
+                .get_one::<String>(Self::MSG)
+                .unwrap()
+                .parse::<Bytes>()
+                .map_err(|_| "Message body must be a hexadecimal string without a 0x prefix")?,
+        })
+    }
+}

--- a/rust/hyperlane-cli/src/args.rs
+++ b/rust/hyperlane-cli/src/args.rs
@@ -1,27 +1,45 @@
-use clap::{Arg, Command};
+use clap::{
+    error::ErrorKind,
+    {Arg, Command, Error},
+};
 use ethers::{
     core::types::{Address, Bytes, H160, H256},
     prelude::LocalWallet,
 };
+use std::fs;
+
+use crate::matching_list;
 
 #[derive(Debug)]
-pub struct Args {
-    pub rpc_url: String,
-    pub mailbox_addr: Address,
-    pub pkey: LocalWallet,
-    pub dest_chain_id: u32,
-    pub recip_addr: H256,
-    pub msg: Bytes,
+pub enum Args {
+    Dispatch {
+        rpc_url: String,
+        mailbox_addr: Address,
+        pkey: LocalWallet,
+        dest_chain_id: u32,
+        recip_addr: H256,
+        msg: Bytes,
+    },
+    Search {
+        rpc_url: String,
+        mailbox_addr: Address,
+        matching_list: matching_list::MatchingList,
+    },
 }
+
+#[derive(Debug, Clone)]
+struct ArgsError;
 
 impl Args {
     const DISPATCH: &str = "dispatch";
+    const SEARCH: &str = "search";
     const RPC_URL: &str = "RPC URL";
     const MAILBOX_ADDR: &str = "mailbox address";
     const PKEY: &str = "private key";
     const DEST_CHAIN_ID: &str = "destination chain ID";
     const RECIP_ADDR: &str = "recipient address";
     const MSG: &str = "message";
+    const MATCHING_LIST: &str = "matching list";
     pub fn new() -> Result<Args, Box<dyn std::error::Error>> {
         let matches = Command::new("hyperlane-cli")
             .about("CLI tool for dispatching Hyperlane messages and watching for Hyperlane events")
@@ -67,46 +85,92 @@ impl Args {
                             .help("Message to be dispatched"),
                     ),
             )
+            .subcommand(
+                Command::new(Self::SEARCH)
+                    .about("Searches for message dispatched from a target chain, matching against a provided criteria")
+                    .arg(
+                        Arg::new(Self::RPC_URL)
+                            .long("rpc")
+                            .required(true)
+                            .help("Origin chain RPC URL"),
+                    )
+                    .arg(
+                        Arg::new(Self::MAILBOX_ADDR)
+                            .long("mailbox")
+                            .required(true)
+                            .help("Mailbox address on the origin chain"),
+                    )
+                    .arg(
+                        Arg::new(Self::MATCHING_LIST)
+                            .required(true)
+                            .help("Path to a JSON file containing a list of matching criteria for filtering messages"),
+                    ),
+            )
             .get_matches();
-        let dispatch_matches = matches.subcommand_matches(Self::DISPATCH).unwrap();
-        Ok(Args {
-            rpc_url: dispatch_matches
-                .get_one::<String>(Self::RPC_URL)
-                .unwrap()
-                .to_string(),
-            mailbox_addr: dispatch_matches
-                .get_one::<String>(Self::MAILBOX_ADDR)
-                .unwrap()
-                .parse::<Address>()
-                .map_err(|_| {
-                    "Mailbox address must be a 20-byte hexadecimal string without a 0x prefix"
-                })?,
-            pkey: dispatch_matches
-                .get_one::<String>(Self::PKEY)
-                .unwrap()
-                .parse::<LocalWallet>()
-                .map_err(|_| {
-                    "Signing key must be a 32-byte hexadecimal string without a 0x prefix"
-                })?,
-            dest_chain_id: dispatch_matches
-                .get_one::<String>(Self::DEST_CHAIN_ID)
-                .unwrap()
-                .parse::<u32>()
-                .map_err(|_| "Destination chain ID must be a number")?,
-            recip_addr: H256::from(
-                dispatch_matches
-                    .get_one::<String>(Self::RECIP_ADDR)
-                    .unwrap()
-                    .parse::<H160>()
-                    .map_err(|_| {
-                        "Recipient address must be a 20-byte hexadecimal string without a 0x prefix"
-                    })?,
-            ),
-            msg: dispatch_matches
-                .get_one::<String>(Self::MSG)
-                .unwrap()
-                .parse::<Bytes>()
-                .map_err(|_| "Message body must be a hexadecimal string without a 0x prefix")?,
-        })
+        match matches.subcommand() {
+            Some((Self::DISPATCH, dispatch_matches)) => {
+                Ok(Args::Dispatch {
+                    rpc_url: dispatch_matches
+                        .get_one::<String>(Self::RPC_URL)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .to_string(),
+                    mailbox_addr: dispatch_matches
+                        .get_one::<String>(Self::MAILBOX_ADDR)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .parse::<Address>()
+                        .map_err(|_| {
+                            "Mailbox address must be a 20-byte hexadecimal string without a 0x prefix"
+                        })?,
+                    pkey: dispatch_matches
+                        .get_one::<String>(Self::PKEY)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .parse::<LocalWallet>()
+                        .map_err(|_| {
+                            "Signing key must be a 32-byte hexadecimal string without a 0x prefix"
+                        })?,
+                    dest_chain_id: dispatch_matches
+                        .get_one::<String>(Self::DEST_CHAIN_ID)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .parse::<u32>()
+                        .map_err(|_| "Destination chain ID must be a number")?,
+                    recip_addr: H256::from(
+                        dispatch_matches
+                            .get_one::<String>(Self::RECIP_ADDR)
+                            .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                            .parse::<H160>()
+                            .map_err(|_| {
+                                "Recipient address must be a 20-byte hexadecimal string without a 0x prefix"
+                            })?,
+                    ),
+                    msg: dispatch_matches
+                        .get_one::<String>(Self::MSG)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .parse::<Bytes>()
+                        .map_err(|_| "Message body must be a hexadecimal string without a 0x prefix")?,
+                })
+            },
+            Some((Self::SEARCH, search_matches)) => {
+                let matching_list_str = fs::read_to_string(search_matches
+                    .get_one::<String>(Self::MATCHING_LIST)
+                    .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                )?;
+                let matching_list = serde_json::from_str(matching_list_str.as_str())?;
+                Ok(Args::Search {
+                    rpc_url: search_matches
+                        .get_one::<String>(Self::RPC_URL)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .to_string(),
+                    mailbox_addr: search_matches
+                        .get_one::<String>(Self::MAILBOX_ADDR)
+                        .ok_or(Error::new(ErrorKind::MissingRequiredArgument))?
+                        .parse::<Address>()
+                        .map_err(|_| {
+                            "Mailbox address must be a 20-byte hexadecimal string without a 0x prefix"
+                        })?,
+                    matching_list: matching_list,
+                })
+            },
+            _ => { Err(Box::new(Error::new(ErrorKind::MissingSubcommand))) }
+        }
     }
 }

--- a/rust/hyperlane-cli/src/mailbox.rs
+++ b/rust/hyperlane-cli/src/mailbox.rs
@@ -1,0 +1,883 @@
+pub use mailbox::*;
+#[allow(clippy::too_many_arguments, non_camel_case_types)]
+pub mod mailbox {
+    #![allow(clippy::enum_variant_names)]
+    #![allow(dead_code)]
+    #![allow(clippy::type_complexity)]
+    #![allow(unused_imports)]
+    use ethers::contract::{
+        builders::{ContractCall, Event},
+        Contract, Lazy,
+    };
+    use ethers::core::{
+        abi::{Abi, Detokenize, InvalidOutputType, Token, Tokenizable},
+        types::*,
+    };
+    use ethers::providers::Middleware;
+    #[doc = "Mailbox was auto-generated with ethers-rs Abigen. More information at: https://github.com/gakonst/ethers-rs"]
+    use std::sync::Arc;
+    # [rustfmt :: skip] const __ABI : & str = "[\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"sender\",\n        \"type\": \"address\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"uint32\",\n        \"name\": \"destination\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipient\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes\",\n        \"name\": \"message\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"Dispatch\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"DispatchId\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"uint32\",\n        \"name\": \"origin\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"sender\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"recipient\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"Process\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"ProcessId\",\n    \"type\": \"event\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"defaultHook\",\n    \"outputs\": [\n      {\n        \"internalType\": \"contract IPostDispatchHook\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"defaultIsm\",\n    \"outputs\": [\n      {\n        \"internalType\": \"contract IInterchainSecurityModule\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"delivered\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"destinationDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipientAddress\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"body\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"defaultHookMetadata\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"dispatch\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"payable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"destinationDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipientAddress\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"body\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"contract IPostDispatchHook\",\n        \"name\": \"customHook\",\n        \"type\": \"address\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"customHookMetadata\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"dispatch\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"payable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"destinationDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipientAddress\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"messageBody\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"dispatch\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageId\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"payable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"latestDispatchedId\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"localDomain\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"nonce\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"metadata\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"message\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"process\",\n    \"outputs\": [],\n    \"stateMutability\": \"payable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"destinationDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipientAddress\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"messageBody\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"quoteDispatch\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"fee\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"destinationDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"recipientAddress\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"messageBody\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"defaultHookMetadata\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"quoteDispatch\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"fee\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"recipient\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"recipientIsm\",\n    \"outputs\": [\n      {\n        \"internalType\": \"contract IInterchainSecurityModule\",\n        \"name\": \"module\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"requiredHook\",\n    \"outputs\": [\n      {\n        \"internalType\": \"contract IPostDispatchHook\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  }\n]\n" ;
+    #[doc = r" The parsed JSON-ABI of the contract."]
+    pub static MAILBOX_ABI: ethers::contract::Lazy<ethers::core::abi::Abi> =
+        ethers::contract::Lazy::new(|| {
+            ethers::core::utils::__serde_json::from_str(__ABI).expect("invalid abi")
+        });
+    pub struct Mailbox<M>(ethers::contract::Contract<M>);
+    impl<M> Clone for Mailbox<M> {
+        fn clone(&self) -> Self {
+            Mailbox(self.0.clone())
+        }
+    }
+    impl<M> std::ops::Deref for Mailbox<M> {
+        type Target = ethers::contract::Contract<M>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<M> std::fmt::Debug for Mailbox<M> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_tuple(stringify!(Mailbox))
+                .field(&self.address())
+                .finish()
+        }
+    }
+    impl<M: ethers::providers::Middleware> Mailbox<M> {
+        #[doc = r" Creates a new contract instance with the specified `ethers`"]
+        #[doc = r" client at the given `Address`. The contract derefs to a `ethers::Contract`"]
+        #[doc = r" object"]
+        pub fn new<T: Into<ethers::core::types::Address>>(
+            address: T,
+            client: ::std::sync::Arc<M>,
+        ) -> Self {
+            ethers::contract::Contract::new(address.into(), MAILBOX_ABI.clone(), client).into()
+        }
+        #[doc = "Calls the contract's `defaultHook` (0x3d1250b7) function"]
+        pub fn default_hook(
+            &self,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::Address> {
+            self.0
+                .method_hash([61, 18, 80, 183], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `defaultIsm` (0x6e5f516e) function"]
+        pub fn default_ism(
+            &self,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::Address> {
+            self.0
+                .method_hash([110, 95, 81, 110], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `delivered` (0xe495f1d4) function"]
+        pub fn delivered(
+            &self,
+            message_id: [u8; 32],
+        ) -> ethers::contract::builders::ContractCall<M, bool> {
+            self.0
+                .method_hash([228, 149, 241, 212], message_id)
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `dispatch` (0x48aee8d4) function"]
+        pub fn dispatch_1(
+            &self,
+            destination_domain: u32,
+            recipient_address: [u8; 32],
+            body: ethers::core::types::Bytes,
+            default_hook_metadata: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
+            self.0
+                .method_hash(
+                    [72, 174, 232, 212],
+                    (
+                        destination_domain,
+                        recipient_address,
+                        body,
+                        default_hook_metadata,
+                    ),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `dispatch` (0xe8a20301) function"]
+        pub fn dispatch_2(
+            &self,
+            destination_domain: u32,
+            recipient_address: [u8; 32],
+            body: ethers::core::types::Bytes,
+            custom_hook: ethers::core::types::Address,
+            custom_hook_metadata: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
+            self.0
+                .method_hash(
+                    [232, 162, 3, 1],
+                    (
+                        destination_domain,
+                        recipient_address,
+                        body,
+                        custom_hook,
+                        custom_hook_metadata,
+                    ),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `dispatch` (0xfa31de01) function"]
+        pub fn dispatch_0(
+            &self,
+            destination_domain: u32,
+            recipient_address: [u8; 32],
+            message_body: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
+            self.0
+                .method_hash(
+                    [250, 49, 222, 1],
+                    (destination_domain, recipient_address, message_body),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `latestDispatchedId` (0x134fbb4f) function"]
+        pub fn latest_dispatched_id(
+            &self,
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
+            self.0
+                .method_hash([19, 79, 187, 79], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `localDomain` (0x8d3638f4) function"]
+        pub fn local_domain(&self) -> ethers::contract::builders::ContractCall<M, u32> {
+            self.0
+                .method_hash([141, 54, 56, 244], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `nonce` (0xaffed0e0) function"]
+        pub fn nonce(&self) -> ethers::contract::builders::ContractCall<M, u32> {
+            self.0
+                .method_hash([175, 254, 208, 224], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `process` (0x7c39d130) function"]
+        pub fn process(
+            &self,
+            metadata: ethers::core::types::Bytes,
+            message: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([124, 57, 209, 48], (metadata, message))
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `quoteDispatch` (0x9c42bd18) function"]
+        pub fn quote_dispatch(
+            &self,
+            destination_domain: u32,
+            recipient_address: [u8; 32],
+            message_body: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::U256> {
+            self.0
+                .method_hash(
+                    [156, 66, 189, 24],
+                    (destination_domain, recipient_address, message_body),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `quoteDispatch` (0xf7ccd321) function"]
+        pub fn quote_dispatch_with_destination_domain_and_recipient_address_and_default_hook_metadata(
+            &self,
+            destination_domain: u32,
+            recipient_address: [u8; 32],
+            message_body: ethers::core::types::Bytes,
+            default_hook_metadata: ethers::core::types::Bytes,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::U256> {
+            self.0
+                .method_hash(
+                    [247, 204, 211, 33],
+                    (
+                        destination_domain,
+                        recipient_address,
+                        message_body,
+                        default_hook_metadata,
+                    ),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `recipientIsm` (0xe70f48ac) function"]
+        pub fn recipient_ism(
+            &self,
+            recipient: ethers::core::types::Address,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::Address> {
+            self.0
+                .method_hash([231, 15, 72, 172], recipient)
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `requiredHook` (0xd6d08a09) function"]
+        pub fn required_hook(
+            &self,
+        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::Address> {
+            self.0
+                .method_hash([214, 208, 138, 9], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Gets the contract's `Dispatch` event"]
+        pub fn dispatch_filter(&self) -> ethers::contract::builders::Event<M, DispatchFilter> {
+            self.0.event()
+        }
+        #[doc = "Gets the contract's `DispatchId` event"]
+        pub fn dispatch_id_filter(&self) -> ethers::contract::builders::Event<M, DispatchIdFilter> {
+            self.0.event()
+        }
+        #[doc = "Gets the contract's `Process` event"]
+        pub fn process_filter(&self) -> ethers::contract::builders::Event<M, ProcessFilter> {
+            self.0.event()
+        }
+        #[doc = "Gets the contract's `ProcessId` event"]
+        pub fn process_id_filter(&self) -> ethers::contract::builders::Event<M, ProcessIdFilter> {
+            self.0.event()
+        }
+        #[doc = r" Returns an [`Event`](#ethers_contract::builders::Event) builder for all events of this contract"]
+        pub fn events(&self) -> ethers::contract::builders::Event<M, MailboxEvents> {
+            self.0.event_with_filter(Default::default())
+        }
+    }
+    impl<M: ethers::providers::Middleware> From<ethers::contract::Contract<M>> for Mailbox<M> {
+        fn from(contract: ethers::contract::Contract<M>) -> Self {
+            Self(contract)
+        }
+    }
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthEvent,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethevent(name = "Dispatch", abi = "Dispatch(address,uint32,bytes32,bytes)")]
+    pub struct DispatchFilter {
+        #[ethevent(indexed)]
+        pub sender: ethers::core::types::Address,
+        #[ethevent(indexed)]
+        pub destination: u32,
+        #[ethevent(indexed)]
+        pub recipient: [u8; 32],
+        pub message: ethers::core::types::Bytes,
+    }
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthEvent,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethevent(name = "DispatchId", abi = "DispatchId(bytes32)")]
+    pub struct DispatchIdFilter {
+        #[ethevent(indexed)]
+        pub message_id: [u8; 32],
+    }
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthEvent,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethevent(name = "Process", abi = "Process(uint32,bytes32,address)")]
+    pub struct ProcessFilter {
+        #[ethevent(indexed)]
+        pub origin: u32,
+        #[ethevent(indexed)]
+        pub sender: [u8; 32],
+        #[ethevent(indexed)]
+        pub recipient: ethers::core::types::Address,
+    }
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthEvent,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethevent(name = "ProcessId", abi = "ProcessId(bytes32)")]
+    pub struct ProcessIdFilter {
+        #[ethevent(indexed)]
+        pub message_id: [u8; 32],
+    }
+    #[derive(Debug, Clone, PartialEq, Eq, ethers :: contract :: EthAbiType)]
+    pub enum MailboxEvents {
+        DispatchFilter(DispatchFilter),
+        DispatchIdFilter(DispatchIdFilter),
+        ProcessFilter(ProcessFilter),
+        ProcessIdFilter(ProcessIdFilter),
+    }
+    impl ethers::contract::EthLogDecode for MailboxEvents {
+        fn decode_log(
+            log: &ethers::core::abi::RawLog,
+        ) -> ::std::result::Result<Self, ethers::core::abi::Error>
+        where
+            Self: Sized,
+        {
+            if let Ok(decoded) = DispatchFilter::decode_log(log) {
+                return Ok(MailboxEvents::DispatchFilter(decoded));
+            }
+            if let Ok(decoded) = DispatchIdFilter::decode_log(log) {
+                return Ok(MailboxEvents::DispatchIdFilter(decoded));
+            }
+            if let Ok(decoded) = ProcessFilter::decode_log(log) {
+                return Ok(MailboxEvents::ProcessFilter(decoded));
+            }
+            if let Ok(decoded) = ProcessIdFilter::decode_log(log) {
+                return Ok(MailboxEvents::ProcessIdFilter(decoded));
+            }
+            Err(ethers::core::abi::Error::InvalidData)
+        }
+    }
+    impl ::std::fmt::Display for MailboxEvents {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match self {
+                MailboxEvents::DispatchFilter(element) => element.fmt(f),
+                MailboxEvents::DispatchIdFilter(element) => element.fmt(f),
+                MailboxEvents::ProcessFilter(element) => element.fmt(f),
+                MailboxEvents::ProcessIdFilter(element) => element.fmt(f),
+            }
+        }
+    }
+    #[doc = "Container type for all input parameters for the `defaultHook` function with signature `defaultHook()` and selector `[61, 18, 80, 183]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "defaultHook", abi = "defaultHook()")]
+    pub struct DefaultHookCall;
+    #[doc = "Container type for all input parameters for the `defaultIsm` function with signature `defaultIsm()` and selector `[110, 95, 81, 110]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "defaultIsm", abi = "defaultIsm()")]
+    pub struct DefaultIsmCall;
+    #[doc = "Container type for all input parameters for the `delivered` function with signature `delivered(bytes32)` and selector `[228, 149, 241, 212]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "delivered", abi = "delivered(bytes32)")]
+    pub struct DeliveredCall {
+        pub message_id: [u8; 32],
+    }
+    #[doc = "Container type for all input parameters for the `dispatch` function with signature `dispatch(uint32,bytes32,bytes,bytes)` and selector `[72, 174, 232, 212]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "dispatch", abi = "dispatch(uint32,bytes32,bytes,bytes)")]
+    pub struct Dispatch1Call {
+        pub destination_domain: u32,
+        pub recipient_address: [u8; 32],
+        pub body: ethers::core::types::Bytes,
+        pub default_hook_metadata: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `dispatch` function with signature `dispatch(uint32,bytes32,bytes,address,bytes)` and selector `[232, 162, 3, 1]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(
+        name = "dispatch",
+        abi = "dispatch(uint32,bytes32,bytes,address,bytes)"
+    )]
+    pub struct Dispatch2Call {
+        pub destination_domain: u32,
+        pub recipient_address: [u8; 32],
+        pub body: ethers::core::types::Bytes,
+        pub custom_hook: ethers::core::types::Address,
+        pub custom_hook_metadata: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `dispatch` function with signature `dispatch(uint32,bytes32,bytes)` and selector `[250, 49, 222, 1]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "dispatch", abi = "dispatch(uint32,bytes32,bytes)")]
+    pub struct Dispatch0Call {
+        pub destination_domain: u32,
+        pub recipient_address: [u8; 32],
+        pub message_body: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `latestDispatchedId` function with signature `latestDispatchedId()` and selector `[19, 79, 187, 79]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "latestDispatchedId", abi = "latestDispatchedId()")]
+    pub struct LatestDispatchedIdCall;
+    #[doc = "Container type for all input parameters for the `localDomain` function with signature `localDomain()` and selector `[141, 54, 56, 244]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "localDomain", abi = "localDomain()")]
+    pub struct LocalDomainCall;
+    #[doc = "Container type for all input parameters for the `nonce` function with signature `nonce()` and selector `[175, 254, 208, 224]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "nonce", abi = "nonce()")]
+    pub struct NonceCall;
+    #[doc = "Container type for all input parameters for the `process` function with signature `process(bytes,bytes)` and selector `[124, 57, 209, 48]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "process", abi = "process(bytes,bytes)")]
+    pub struct ProcessCall {
+        pub metadata: ethers::core::types::Bytes,
+        pub message: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `quoteDispatch` function with signature `quoteDispatch(uint32,bytes32,bytes)` and selector `[156, 66, 189, 24]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "quoteDispatch", abi = "quoteDispatch(uint32,bytes32,bytes)")]
+    pub struct QuoteDispatchCall {
+        pub destination_domain: u32,
+        pub recipient_address: [u8; 32],
+        pub message_body: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `quoteDispatch` function with signature `quoteDispatch(uint32,bytes32,bytes,bytes)` and selector `[247, 204, 211, 33]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(
+        name = "quoteDispatch",
+        abi = "quoteDispatch(uint32,bytes32,bytes,bytes)"
+    )]
+    pub struct QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataCall {
+        pub destination_domain: u32,
+        pub recipient_address: [u8; 32],
+        pub message_body: ethers::core::types::Bytes,
+        pub default_hook_metadata: ethers::core::types::Bytes,
+    }
+    #[doc = "Container type for all input parameters for the `recipientIsm` function with signature `recipientIsm(address)` and selector `[231, 15, 72, 172]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "recipientIsm", abi = "recipientIsm(address)")]
+    pub struct RecipientIsmCall {
+        pub recipient: ethers::core::types::Address,
+    }
+    #[doc = "Container type for all input parameters for the `requiredHook` function with signature `requiredHook()` and selector `[214, 208, 138, 9]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+        Default,
+    )]
+    #[ethcall(name = "requiredHook", abi = "requiredHook()")]
+    pub struct RequiredHookCall;
+    #[derive(Debug, Clone, PartialEq, Eq, ethers :: contract :: EthAbiType)]
+    pub enum MailboxCalls {
+        DefaultHook(DefaultHookCall),
+        DefaultIsm(DefaultIsmCall),
+        Delivered(DeliveredCall),
+        Dispatch1(Dispatch1Call),
+        Dispatch2(Dispatch2Call),
+        Dispatch0(Dispatch0Call),
+        LatestDispatchedId(LatestDispatchedIdCall),
+        LocalDomain(LocalDomainCall),
+        Nonce(NonceCall),
+        Process(ProcessCall),
+        QuoteDispatch(QuoteDispatchCall),
+        QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadata(
+            QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataCall,
+        ),
+        RecipientIsm(RecipientIsmCall),
+        RequiredHook(RequiredHookCall),
+    }
+    impl ethers::core::abi::AbiDecode for MailboxCalls {
+        fn decode(
+            data: impl AsRef<[u8]>,
+        ) -> ::std::result::Result<Self, ethers::core::abi::AbiError> {
+            if let Ok(decoded) =
+                <DefaultHookCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::DefaultHook(decoded));
+            }
+            if let Ok(decoded) =
+                <DefaultIsmCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::DefaultIsm(decoded));
+            }
+            if let Ok(decoded) =
+                <DeliveredCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Delivered(decoded));
+            }
+            if let Ok(decoded) =
+                <Dispatch1Call as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Dispatch1(decoded));
+            }
+            if let Ok(decoded) =
+                <Dispatch2Call as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Dispatch2(decoded));
+            }
+            if let Ok(decoded) =
+                <Dispatch0Call as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Dispatch0(decoded));
+            }
+            if let Ok(decoded) =
+                <LatestDispatchedIdCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::LatestDispatchedId(decoded));
+            }
+            if let Ok(decoded) =
+                <LocalDomainCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::LocalDomain(decoded));
+            }
+            if let Ok(decoded) = <NonceCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Nonce(decoded));
+            }
+            if let Ok(decoded) =
+                <ProcessCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::Process(decoded));
+            }
+            if let Ok(decoded) =
+                <QuoteDispatchCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::QuoteDispatch(decoded));
+            }
+            if let Ok (decoded) = < QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataCall as ethers :: core :: abi :: AbiDecode > :: decode (data . as_ref ()) { return Ok (MailboxCalls :: QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadata (decoded)) }
+            if let Ok(decoded) =
+                <RecipientIsmCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::RecipientIsm(decoded));
+            }
+            if let Ok(decoded) =
+                <RequiredHookCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(MailboxCalls::RequiredHook(decoded));
+            }
+            Err(ethers::core::abi::Error::InvalidData.into())
+        }
+    }
+    impl ethers::core::abi::AbiEncode for MailboxCalls {
+        fn encode(self) -> Vec<u8> {
+            match self { MailboxCalls :: DefaultHook (element) => element . encode () , MailboxCalls :: DefaultIsm (element) => element . encode () , MailboxCalls :: Delivered (element) => element . encode () , MailboxCalls :: Dispatch1 (element) => element . encode () , MailboxCalls :: Dispatch2 (element) => element . encode () , MailboxCalls :: Dispatch0 (element) => element . encode () , MailboxCalls :: LatestDispatchedId (element) => element . encode () , MailboxCalls :: LocalDomain (element) => element . encode () , MailboxCalls :: Nonce (element) => element . encode () , MailboxCalls :: Process (element) => element . encode () , MailboxCalls :: QuoteDispatch (element) => element . encode () , MailboxCalls :: QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadata (element) => element . encode () , MailboxCalls :: RecipientIsm (element) => element . encode () , MailboxCalls :: RequiredHook (element) => element . encode () }
+        }
+    }
+    impl ::std::fmt::Display for MailboxCalls {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match self { MailboxCalls :: DefaultHook (element) => element . fmt (f) , MailboxCalls :: DefaultIsm (element) => element . fmt (f) , MailboxCalls :: Delivered (element) => element . fmt (f) , MailboxCalls :: Dispatch1 (element) => element . fmt (f) , MailboxCalls :: Dispatch2 (element) => element . fmt (f) , MailboxCalls :: Dispatch0 (element) => element . fmt (f) , MailboxCalls :: LatestDispatchedId (element) => element . fmt (f) , MailboxCalls :: LocalDomain (element) => element . fmt (f) , MailboxCalls :: Nonce (element) => element . fmt (f) , MailboxCalls :: Process (element) => element . fmt (f) , MailboxCalls :: QuoteDispatch (element) => element . fmt (f) , MailboxCalls :: QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadata (element) => element . fmt (f) , MailboxCalls :: RecipientIsm (element) => element . fmt (f) , MailboxCalls :: RequiredHook (element) => element . fmt (f) }
+        }
+    }
+    impl ::std::convert::From<DefaultHookCall> for MailboxCalls {
+        fn from(var: DefaultHookCall) -> Self {
+            MailboxCalls::DefaultHook(var)
+        }
+    }
+    impl ::std::convert::From<DefaultIsmCall> for MailboxCalls {
+        fn from(var: DefaultIsmCall) -> Self {
+            MailboxCalls::DefaultIsm(var)
+        }
+    }
+    impl ::std::convert::From<DeliveredCall> for MailboxCalls {
+        fn from(var: DeliveredCall) -> Self {
+            MailboxCalls::Delivered(var)
+        }
+    }
+    impl ::std::convert::From<Dispatch1Call> for MailboxCalls {
+        fn from(var: Dispatch1Call) -> Self {
+            MailboxCalls::Dispatch1(var)
+        }
+    }
+    impl ::std::convert::From<Dispatch2Call> for MailboxCalls {
+        fn from(var: Dispatch2Call) -> Self {
+            MailboxCalls::Dispatch2(var)
+        }
+    }
+    impl ::std::convert::From<Dispatch0Call> for MailboxCalls {
+        fn from(var: Dispatch0Call) -> Self {
+            MailboxCalls::Dispatch0(var)
+        }
+    }
+    impl ::std::convert::From<LatestDispatchedIdCall> for MailboxCalls {
+        fn from(var: LatestDispatchedIdCall) -> Self {
+            MailboxCalls::LatestDispatchedId(var)
+        }
+    }
+    impl ::std::convert::From<LocalDomainCall> for MailboxCalls {
+        fn from(var: LocalDomainCall) -> Self {
+            MailboxCalls::LocalDomain(var)
+        }
+    }
+    impl ::std::convert::From<NonceCall> for MailboxCalls {
+        fn from(var: NonceCall) -> Self {
+            MailboxCalls::Nonce(var)
+        }
+    }
+    impl ::std::convert::From<ProcessCall> for MailboxCalls {
+        fn from(var: ProcessCall) -> Self {
+            MailboxCalls::Process(var)
+        }
+    }
+    impl ::std::convert::From<QuoteDispatchCall> for MailboxCalls {
+        fn from(var: QuoteDispatchCall) -> Self {
+            MailboxCalls::QuoteDispatch(var)
+        }
+    }
+    impl
+        ::std::convert::From<
+            QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataCall,
+        > for MailboxCalls
+    {
+        fn from(
+            var: QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataCall,
+        ) -> Self {
+            MailboxCalls :: QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadata (var)
+        }
+    }
+    impl ::std::convert::From<RecipientIsmCall> for MailboxCalls {
+        fn from(var: RecipientIsmCall) -> Self {
+            MailboxCalls::RecipientIsm(var)
+        }
+    }
+    impl ::std::convert::From<RequiredHookCall> for MailboxCalls {
+        fn from(var: RequiredHookCall) -> Self {
+            MailboxCalls::RequiredHook(var)
+        }
+    }
+    #[doc = "Container type for all return fields from the `defaultHook` function with signature `defaultHook()` and selector `[61, 18, 80, 183]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct DefaultHookReturn(pub ethers::core::types::Address);
+    #[doc = "Container type for all return fields from the `defaultIsm` function with signature `defaultIsm()` and selector `[110, 95, 81, 110]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct DefaultIsmReturn(pub ethers::core::types::Address);
+    #[doc = "Container type for all return fields from the `delivered` function with signature `delivered(bytes32)` and selector `[228, 149, 241, 212]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct DeliveredReturn(pub bool);
+    #[doc = "Container type for all return fields from the `dispatch` function with signature `dispatch(uint32,bytes32,bytes,bytes)` and selector `[72, 174, 232, 212]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct Dispatch1Return {
+        pub message_id: [u8; 32],
+    }
+    #[doc = "Container type for all return fields from the `dispatch` function with signature `dispatch(uint32,bytes32,bytes,address,bytes)` and selector `[232, 162, 3, 1]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct Dispatch2Return {
+        pub message_id: [u8; 32],
+    }
+    #[doc = "Container type for all return fields from the `dispatch` function with signature `dispatch(uint32,bytes32,bytes)` and selector `[250, 49, 222, 1]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct Dispatch0Return {
+        pub message_id: [u8; 32],
+    }
+    #[doc = "Container type for all return fields from the `latestDispatchedId` function with signature `latestDispatchedId()` and selector `[19, 79, 187, 79]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct LatestDispatchedIdReturn(pub [u8; 32]);
+    #[doc = "Container type for all return fields from the `localDomain` function with signature `localDomain()` and selector `[141, 54, 56, 244]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct LocalDomainReturn(pub u32);
+    #[doc = "Container type for all return fields from the `nonce` function with signature `nonce()` and selector `[175, 254, 208, 224]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct NonceReturn(pub u32);
+    #[doc = "Container type for all return fields from the `quoteDispatch` function with signature `quoteDispatch(uint32,bytes32,bytes)` and selector `[156, 66, 189, 24]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct QuoteDispatchReturn {
+        pub fee: ethers::core::types::U256,
+    }
+    #[doc = "Container type for all return fields from the `quoteDispatch` function with signature `quoteDispatch(uint32,bytes32,bytes,bytes)` and selector `[247, 204, 211, 33]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct QuoteDispatchWithDestinationDomainAndRecipientAddressAndDefaultHookMetadataReturn {
+        pub fee: ethers::core::types::U256,
+    }
+    #[doc = "Container type for all return fields from the `recipientIsm` function with signature `recipientIsm(address)` and selector `[231, 15, 72, 172]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct RecipientIsmReturn {
+        pub module: ethers::core::types::Address,
+    }
+    #[doc = "Container type for all return fields from the `requiredHook` function with signature `requiredHook()` and selector `[214, 208, 138, 9]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthAbiType,
+        ethers :: contract :: EthAbiCodec,
+        Default,
+    )]
+    pub struct RequiredHookReturn(pub ethers::core::types::Address);
+}

--- a/rust/hyperlane-cli/src/main.rs
+++ b/rust/hyperlane-cli/src/main.rs
@@ -1,60 +1,102 @@
 use std::sync::Arc;
 
 use ethers::{
-    prelude::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
+    core::types::{Address, Bytes, H256},
+    prelude::{LocalWallet, SignerMiddleware},
+    providers::{Http, Middleware, Provider, StreamExt},
     signers::Signer,
 };
 
+use hyperlane_core::HyperlaneMessage;
+
 mod args;
 mod mailbox;
+mod matching_list;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = args::Args::new()?;
-
+async fn dispatch(
+    rpc_url: String,
+    mailbox_addr: Address,
+    pkey: LocalWallet,
+    dest_chain_id: u32,
+    recip_addr: H256,
+    msg: Bytes,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Connect to the origin chain and determine it's chain ID
-    let provider = Arc::new(Provider::<Http>::try_from(args.rpc_url.clone())?);
+    let provider = Arc::new(Provider::<Http>::try_from(rpc_url.clone())?);
     let origin_chain_id = provider.get_chainid().await?.as_u32();
     println!(
         "Connected to network via {}, chain ID is {}",
-        args.rpc_url, origin_chain_id
+        rpc_url, origin_chain_id
     );
 
     // Build an interface to the origin chain's mailbox,
     // include signer middleware in order to send transactions
-    let wallet = args.pkey.with_chain_id(origin_chain_id);
+    let wallet = pkey.with_chain_id(origin_chain_id);
     let provider = Arc::new(SignerMiddleware::new(provider, wallet));
-    let contract = mailbox::Mailbox::new(args.mailbox_addr, provider.clone());
+    let contract = mailbox::Mailbox::new(mailbox_addr, provider.clone());
 
-    /*
-     * TODO: Determine the proper formula for gas calculation.
-     * Currently, the gas used in a transaction is the sum of
-     * ether-rs' gas estimation and the mailbox's quote.
-     */
     // Receive a quote from mailbox for the dispatched message's gas cost
-    let quote_dispatch = contract.quote_dispatch(
-        args.dest_chain_id,
-        args.recip_addr.to_fixed_bytes(),
-        args.msg.clone(),
-    );
+    let quote_dispatch =
+        contract.quote_dispatch(dest_chain_id, recip_addr.to_fixed_bytes(), msg.clone());
     let quote = quote_dispatch.call().await?;
     println!("Mailbox's gas quote for this message is: {quote}");
 
     // Assemble dispatch transaction
-    let dispatch = contract.dispatch_0(
-        args.dest_chain_id,
-        args.recip_addr.to_fixed_bytes(),
-        args.msg.clone(),
-    );
+    let dispatch = contract.dispatch_0(dest_chain_id, recip_addr.to_fixed_bytes(), msg.clone());
     let gas_price = provider.get_gas_price().await?;
-    let gas = dispatch.estimate_gas().await? + quote;
+    println!("Average gas price: {gas_price}");
+    let gas = dispatch.estimate_gas().await?;
     println!("Transaction gas estimate: {gas}\nAverage gas price: {gas_price}");
     let dispatch = dispatch.gas(gas).gas_price(gas_price);
 
     // Send dispatch transaction
     let tx_hash = dispatch.send().await?.tx_hash();
     println!("Dispatch transaction is pending: https://etherscan.io/tx/{tx_hash:?}");
-
     Ok(())
+}
+
+async fn search(
+    rpc_url: String,
+    mailbox_addr: Address,
+    matching_list: matching_list::MatchingList,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let provider = Arc::new(Provider::<Http>::try_from(rpc_url.clone())?);
+    let origin_chain_id = provider.get_chainid().await?.as_u32();
+    println!(
+        "Connected to network via {}, chain ID is {}",
+        rpc_url, origin_chain_id
+    );
+
+    // Build an interface to the origin chain's mailbox,
+    let contract = mailbox::Mailbox::new(mailbox_addr, provider.clone());
+
+    let event = contract.event::<mailbox::DispatchFilter>();
+    let mut event_stream = event.stream().await?;
+
+    while let Some(Ok(dispatch_filter)) = event_stream.next().await {
+        let hyperlane_msg: HyperlaneMessage = dispatch_filter.message.to_vec().into();
+        if matching_list.msg_matches(&hyperlane_msg, false) {
+            println!("{:?}", hyperlane_msg);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    match args::Args::new()? {
+        args::Args::Dispatch {
+            rpc_url,
+            mailbox_addr,
+            pkey,
+            dest_chain_id,
+            recip_addr,
+            msg,
+        } => dispatch(rpc_url, mailbox_addr, pkey, dest_chain_id, recip_addr, msg).await,
+        args::Args::Search {
+            rpc_url,
+            mailbox_addr,
+            matching_list,
+        } => search(rpc_url, mailbox_addr, matching_list).await,
+    }
 }

--- a/rust/hyperlane-cli/src/main.rs
+++ b/rust/hyperlane-cli/src/main.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use ethers::{
+    prelude::SignerMiddleware,
+    providers::{Http, Middleware, Provider},
+    signers::Signer,
+};
+
+mod args;
+mod mailbox;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = args::Args::new()?;
+
+    // Connect to the origin chain and determine it's chain ID
+    let provider = Arc::new(Provider::<Http>::try_from(args.rpc_url.clone())?);
+    let origin_chain_id = provider.get_chainid().await?.as_u32();
+    println!(
+        "Connected to network via {}, chain ID is {}",
+        args.rpc_url, origin_chain_id
+    );
+
+    // Build an interface to the origin chain's mailbox,
+    // include signer middleware in order to send transactions
+    let wallet = args.pkey.with_chain_id(origin_chain_id);
+    let provider = Arc::new(SignerMiddleware::new(provider, wallet));
+    let contract = mailbox::Mailbox::new(args.mailbox_addr, provider.clone());
+
+    /*
+     * TODO: Determine the proper formula for gas calculation.
+     * Currently, the gas used in a transaction is the sum of
+     * ether-rs' gas estimation and the mailbox's quote.
+     */
+    // Receive a quote from mailbox for the dispatched message's gas cost
+    let quote_dispatch = contract.quote_dispatch(
+        args.dest_chain_id,
+        args.recip_addr.to_fixed_bytes(),
+        args.msg.clone(),
+    );
+    let quote = quote_dispatch.call().await?;
+    println!("Mailbox's gas quote for this message is: {quote}");
+
+    // Assemble dispatch transaction
+    let dispatch = contract.dispatch_0(
+        args.dest_chain_id,
+        args.recip_addr.to_fixed_bytes(),
+        args.msg.clone(),
+    );
+    let gas_price = provider.get_gas_price().await?;
+    let gas = dispatch.estimate_gas().await? + quote;
+    println!("Transaction gas estimate: {gas}\nAverage gas price: {gas_price}");
+    let dispatch = dispatch.gas(gas).gas_price(gas_price);
+
+    // Send dispatch transaction
+    let tx_hash = dispatch.send().await?.tx_hash();
+    println!("Dispatch transaction is pending: https://etherscan.io/tx/{tx_hash:?}");
+
+    Ok(())
+}

--- a/rust/hyperlane-cli/src/matching_list.rs
+++ b/rust/hyperlane-cli/src/matching_list.rs
@@ -1,0 +1,474 @@
+/*
+ * This file has been copied directly from 'rust/agents/relayer/src/settings/matching_list.rs'.
+ * I decided to copy the file directly rather than exposing the Relayer agent as a library to be consumed by hyperlane-cli.
+ * For long term use, I would consider refactoring MatchingList into hyperlane-core.
+ */
+
+use std::{
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    marker::PhantomData,
+};
+
+use hyperlane_core::{config::StrOrInt, utils::hex_or_base58_to_h256, HyperlaneMessage, H256};
+use serde::{
+    de::{Error, SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+/// Defines a set of patterns for determining if a message should or should not
+/// be relayed. This is useful for determine if a message matches a given set or
+/// rules.
+///
+/// Valid options for each of the tuple elements are
+/// - wildcard "*"
+/// - single value in decimal or hex (must start with `0x`) format
+/// - list of values in decimal or hex format
+#[derive(Debug, Default, Clone)]
+pub struct MatchingList(Option<Vec<ListElement>>);
+
+#[derive(Debug, Clone, PartialEq)]
+enum Filter<T> {
+    Wildcard,
+    Enumerated(Vec<T>),
+}
+
+impl<T> Default for Filter<T> {
+    fn default() -> Self {
+        Self::Wildcard
+    }
+}
+
+impl<T: PartialEq> Filter<T> {
+    fn matches(&self, v: &T) -> bool {
+        match self {
+            Filter::Wildcard => true,
+            Filter::Enumerated(list) => list.iter().any(|i| i == v),
+        }
+    }
+}
+
+impl<T: Debug> Display for Filter<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Wildcard => write!(f, "*"),
+            Self::Enumerated(l) if l.len() == 1 => write!(f, "{:?}", l[0]),
+            Self::Enumerated(l) => {
+                write!(f, "[")?;
+                for i in l {
+                    write!(f, "{i:?},")?;
+                }
+                write!(f, "]")
+            }
+        }
+    }
+}
+
+struct MatchingListVisitor;
+impl<'de> Visitor<'de> for MatchingListVisitor {
+    type Value = MatchingList;
+
+    fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "an optional list of matching rules")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(MatchingList(None))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let list: Vec<ListElement> = deserializer.deserialize_seq(MatchingListArrayVisitor)?;
+        Ok(if list.is_empty() {
+            // this allows for empty matching lists to be treated as if no matching list was set
+            MatchingList(None)
+        } else {
+            MatchingList(Some(list))
+        })
+    }
+}
+
+struct MatchingListArrayVisitor;
+impl<'de> Visitor<'de> for MatchingListArrayVisitor {
+    type Value = Vec<ListElement>;
+
+    fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "a list of matching rules")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut rules = seq.size_hint().map(Vec::with_capacity).unwrap_or_default();
+        while let Some(rule) = seq.next_element::<ListElement>()? {
+            rules.push(rule);
+        }
+        Ok(rules)
+    }
+}
+
+struct FilterVisitor<T>(PhantomData<T>);
+impl<'de> Visitor<'de> for FilterVisitor<u32> {
+    type Value = Filter<u32>;
+
+    fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "Expecting either a wildcard \"*\", decimal/hex value string, or list of decimal/hex value strings")
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Self::Value::Enumerated(vec![v]))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if v <= u32::MAX as u64 {
+            Ok(Self::Value::Enumerated(vec![v as u32]))
+        } else {
+            Err(E::custom("Domain Id must fit within a u32 value"))
+        }
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(if v == "*" {
+            Self::Value::Wildcard
+        } else {
+            Self::Value::Enumerated(vec![v.parse::<u32>().map_err(to_serde_err)?])
+        })
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(i) = seq.next_element::<StrOrInt>()? {
+            values.push(i.try_into().map_err(to_serde_err)?);
+        }
+        Ok(Self::Value::Enumerated(values))
+    }
+}
+
+impl<'de> Visitor<'de> for FilterVisitor<H256> {
+    type Value = Filter<H256>;
+
+    fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting either a wildcard \"*\", hex/base58 address string, or list of hex/base58 address strings"
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(if v == "*" {
+            Self::Value::Wildcard
+        } else {
+            Self::Value::Enumerated(vec![parse_addr(v)?])
+        })
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(i) = seq.next_element::<String>()? {
+            values.push(parse_addr(&i)?)
+        }
+        Ok(Self::Value::Enumerated(values))
+    }
+}
+
+impl<'de> Deserialize<'de> for MatchingList {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_option(MatchingListVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Filter<u32> {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_any(FilterVisitor::<u32>(Default::default()))
+    }
+}
+
+impl<'de> Deserialize<'de> for Filter<H256> {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_any(FilterVisitor::<H256>(Default::default()))
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "type")]
+struct ListElement {
+    #[serde(default, rename = "origindomain")]
+    origin_domain: Filter<u32>,
+    #[serde(default, rename = "senderaddress")]
+    sender_address: Filter<H256>,
+    #[serde(default, rename = "destinationdomain")]
+    destination_domain: Filter<u32>,
+    #[serde(default, rename = "recipientaddress")]
+    recipient_address: Filter<H256>,
+}
+
+impl Display for ListElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{originDomain: {}, senderAddress: {}, destinationDomain: {}, recipientAddress: {}}}",
+            self.origin_domain,
+            self.sender_address,
+            self.destination_domain,
+            self.recipient_address
+        )
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct MatchInfo<'a> {
+    src_domain: u32,
+    src_addr: &'a H256,
+    dst_domain: u32,
+    dst_addr: &'a H256,
+}
+
+impl<'a> From<&'a HyperlaneMessage> for MatchInfo<'a> {
+    fn from(msg: &'a HyperlaneMessage) -> Self {
+        Self {
+            src_domain: msg.origin,
+            src_addr: &msg.sender,
+            dst_domain: msg.destination,
+            dst_addr: &msg.recipient,
+        }
+    }
+}
+
+impl MatchingList {
+    /// Check if a message matches any of the rules.
+    /// - `default`: What to return if the the matching list is empty.
+    pub fn msg_matches(&self, msg: &HyperlaneMessage, default: bool) -> bool {
+        self.matches(msg.into(), default)
+    }
+
+    /// Check if a message matches any of the rules.
+    /// - `default`: What to return if the the matching list is empty.
+    fn matches(&self, info: MatchInfo, default: bool) -> bool {
+        if let Some(rules) = &self.0 {
+            matches_any_rule(rules.iter(), info)
+        } else {
+            default
+        }
+    }
+}
+
+fn matches_any_rule<'a>(mut rules: impl Iterator<Item = &'a ListElement>, info: MatchInfo) -> bool {
+    rules.any(|rule| {
+        rule.origin_domain.matches(&info.src_domain)
+            && rule.sender_address.matches(info.src_addr)
+            && rule.destination_domain.matches(&info.dst_domain)
+            && rule.recipient_address.matches(info.dst_addr)
+    })
+}
+
+impl Display for MatchingList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if let Some(wl) = &self.0 {
+            write!(f, "[")?;
+            for i in wl {
+                write!(f, "{i},")?;
+            }
+            write!(f, "]")
+        } else {
+            write!(f, "null")
+        }
+    }
+}
+
+fn to_serde_err<IE: ToString, OE: Error>(e: IE) -> OE {
+    OE::custom(e.to_string())
+}
+
+fn parse_addr<E: Error>(addr_str: &str) -> Result<H256, E> {
+    hex_or_base58_to_h256(addr_str).map_err(to_serde_err)
+}
+
+#[cfg(test)]
+mod test {
+    use hyperlane_core::{H160, H256};
+
+    use super::{Filter::*, MatchingList};
+    use crate::settings::matching_list::MatchInfo;
+
+    #[test]
+    fn basic_config() {
+        let list: MatchingList = serde_json::from_str(r#"[{"origindomain": "*", "senderaddress": "*", "destinationdomain": "*", "recipientaddress": "*"}, {}]"#).unwrap();
+        assert!(list.0.is_some());
+        assert_eq!(list.0.as_ref().unwrap().len(), 2);
+        let elem = &list.0.as_ref().unwrap()[0];
+        assert_eq!(elem.destination_domain, Wildcard);
+        assert_eq!(elem.recipient_address, Wildcard);
+        assert_eq!(elem.origin_domain, Wildcard);
+        assert_eq!(elem.sender_address, Wildcard);
+
+        let elem = &list.0.as_ref().unwrap()[1];
+        assert_eq!(elem.destination_domain, Wildcard);
+        assert_eq!(elem.recipient_address, Wildcard);
+        assert_eq!(elem.origin_domain, Wildcard);
+        assert_eq!(elem.sender_address, Wildcard);
+
+        assert!(list.matches(
+            MatchInfo {
+                src_domain: 0,
+                src_addr: &H256::default(),
+                dst_domain: 0,
+                dst_addr: &H256::default()
+            },
+            false
+        ));
+
+        assert!(list.matches(
+            MatchInfo {
+                src_domain: 34,
+                src_addr: &"0x9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                dst_domain: 5456,
+                dst_addr: &H256::default()
+            },
+            false
+        ))
+    }
+
+    #[test]
+    fn config_with_address() {
+        let list: MatchingList = serde_json::from_str(r#"[{"senderaddress": "0x9d4454B023096f34B160D6B654540c56A1F81688", "recipientaddress": "0x9d4454B023096f34B160D6B654540c56A1F81688"}]"#).unwrap();
+        assert!(list.0.is_some());
+        assert_eq!(list.0.as_ref().unwrap().len(), 1);
+        let elem = &list.0.as_ref().unwrap()[0];
+        assert_eq!(elem.destination_domain, Wildcard);
+        assert_eq!(
+            elem.recipient_address,
+            Enumerated(vec!["0x9d4454B023096f34B160D6B654540c56A1F81688"
+                .parse::<H160>()
+                .unwrap()
+                .into()])
+        );
+        assert_eq!(elem.origin_domain, Wildcard);
+        assert_eq!(
+            elem.sender_address,
+            Enumerated(vec!["0x9d4454B023096f34B160D6B654540c56A1F81688"
+                .parse::<H160>()
+                .unwrap()
+                .into()])
+        );
+
+        assert!(list.matches(
+            MatchInfo {
+                src_domain: 34,
+                src_addr: &"0x9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                dst_domain: 5456,
+                dst_addr: &"9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into()
+            },
+            false
+        ));
+
+        assert!(!list.matches(
+            MatchInfo {
+                src_domain: 34,
+                src_addr: &"0x9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                dst_domain: 5456,
+                dst_addr: &H256::default()
+            },
+            false
+        ));
+    }
+
+    #[test]
+    fn config_with_multiple_domains() {
+        let whitelist: MatchingList =
+            serde_json::from_str(r#"[{"destinationdomain": ["13372", "13373"]}]"#).unwrap();
+        assert!(whitelist.0.is_some());
+        assert_eq!(whitelist.0.as_ref().unwrap().len(), 1);
+        let elem = &whitelist.0.as_ref().unwrap()[0];
+        assert_eq!(elem.destination_domain, Enumerated(vec![13372, 13373]));
+        assert_eq!(elem.recipient_address, Wildcard);
+        assert_eq!(elem.origin_domain, Wildcard);
+        assert_eq!(elem.sender_address, Wildcard);
+    }
+
+    #[test]
+    fn config_with_empty_list_is_none() {
+        let whitelist: MatchingList = serde_json::from_str(r#"[]"#).unwrap();
+        assert!(whitelist.0.is_none());
+    }
+
+    #[test]
+    fn matches_empty_list() {
+        let info = MatchInfo {
+            src_domain: 0,
+            src_addr: &H256::default(),
+            dst_domain: 0,
+            dst_addr: &H256::default(),
+        };
+        // whitelist use
+        assert!(MatchingList(None).matches(info, true));
+        // blacklist use
+        assert!(!MatchingList(None).matches(info, false));
+    }
+
+    #[test]
+    fn supports_base58() {
+        serde_json::from_str::<MatchingList>(
+            r#"[{"origindomain":1399811151,"senderaddress":"DdTMkk9nuqH5LnD56HLkPiKMV3yB3BNEYSQfgmJHa5i7","destinationdomain":11155111,"recipientaddress":"0x6AD4DEBA8A147d000C09de6465267a9047d1c217"}]"#,
+        ).unwrap();
+    }
+
+    #[test]
+    fn supports_sequence_h256s() {
+        let json_str = r#"[{"origindomain":1399811151,"senderaddress":["0x6AD4DEBA8A147d000C09de6465267a9047d1c217","0x6AD4DEBA8A147d000C09de6465267a9047d1c218"],"destinationdomain":11155111,"recipientaddress":["0x6AD4DEBA8A147d000C09de6465267a9047d1c217","0x6AD4DEBA8A147d000C09de6465267a9047d1c218"]}]"#;
+
+        // Test parsing directly into MatchingList
+        serde_json::from_str::<MatchingList>(json_str).unwrap();
+
+        // Test parsing into a Value and then into MatchingList, which is the path used
+        // by the agent config parser.
+        let val: serde_json::Value = serde_json::from_str(json_str).unwrap();
+        let value_parser =
+            hyperlane_base::settings::parser::ValueParser::new(Default::default(), &val);
+        crate::settings::parse_matching_list(value_parser).unwrap();
+    }
+}


### PR DESCRIPTION
### Description
Creation of a basic CLI capable of dispatching Hyperlane messages. Mailbox interface is generated during compile-time using the ABI hosted under hyperlane-ethereum. Running `hyperlane-cli` without arguments provides a help prompt explaining usage.

### Testing
Manual, exploratory testing against the Sepolia mailbox, limited testing against the Ethereum mailbox.